### PR TITLE
Fix: Environment Variables for WS_USER_KEY and WS_TOKEN do not work.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,22 @@ jobs:
         run: python setup.py bdist_wheel
       - name: Install Wheel package
         run: ls -1 dist/*.whl | xargs pip install
-      - name: Full test JSON
+      - name: Full test JSON (Organization-Product)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: ${TOOL_NAME} -u ${{ secrets.WS_USER_KEY }} -a saas -k ${{ secrets.WS_ORG_TOKEN }} -s ${{ secrets.WS_PROJ_DJANGO }} -o /tmp/output
+        env:
+          DEBUG: 1
+      - name: Full test JSON (Organization-Product)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: ${TOOL_NAME} -u ${{ secrets.WS_USER_KEY }} -a saas -k ${{ secrets.WS_ORG_TOKEN }} -s ${{ secrets.WS_SCOPE_PROD_JAVA_MAVEN }} -o /tmp/output
         env:
           DEBUG: 1
       - name: Full test RDF
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: ${TOOL_NAME} -u ${{ secrets.WS_USER_KEY }} -k ${{ secrets.WS_ORG_TOKEN }} -s ${{ secrets.WS_PROJ_KUBERNETES }} -t rdf -o /tmp/output
+      - name: Full test xml
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: ${TOOL_NAME} -u ${{ secrets.WS_USER_KEY }} -k ${{ secrets.WS_ORG_TOKEN }} -s ${{ secrets.WS_PROJ_KUBERNETES }} -t xml -o /tmp/output
       - name: Full test TV (tag-value)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: ${TOOL_NAME} -u ${{ secrets.WS_USER_KEY }} -k ${{ secrets.WS_ORG_TOKEN }} -s ${{ secrets.WS_PROJ_CROSS_SITE_SCRIPTING }} -t tv -o /tmp/output

--- a/README.md
+++ b/README.md
@@ -55,9 +55,14 @@ Python 3.8+
 ```shell
 # Create tag value report on a specific project 
 ws_sbom_generator -u <WS_USER_KEY> -k <WS_ORG_TOKEN> -a app-eu -s <WS_PROJECT_TOKEN> -e /<path/to>/sbom_extra.json -o </path/reports>
+
+# Create tag value report on all projects of product 
+ws_sbom_generator -u <WS_USER_KEY> -k <WS_ORG_TOKEN> -a app-eu -s <WS_PRODUCT_TOKEN> -e /<path/to>/sbom_extra.json -o </path/reports>
+
 # Creating JSON report on all projects of organization
 ws_sbom_generator -u <WS_USER_KEY> -k <WS_ORG_TOKEN> -a https://di.whitesourcesoftware.com -t json -o </path/reports>
-# Creating XML report on a project with product permissions (SAAS organization)   
+
+# Creating XML report on a project with a user which only has product permissions (SAAS organization)   
 ws_sbom_generator -u <WS_USER_KEY> -y product -k <WS_PRODUCT_TOKEN> -s <WS_PROJECT_TOKEN> -t xml -e /<path/to>/sbom_extra.json -o </path/reports>
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ws-spdx-tools==0.7.0a3.post5
-ws-sdk~=0.9.0.5
+ws-sdk~=0.9.0.6
 numpy==1.22.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ws-spdx-tools==0.7.0a3.post5
+ws-spdx-tools==0.7.0a3.post6
 ws-sdk~=0.9.0.6
 numpy==1.22.3

--- a/ws_sbom_generator/sbom_generator.py
+++ b/ws_sbom_generator/sbom_generator.py
@@ -284,7 +284,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Utility to create SBOM from WhiteSource data')
     
     if 'WS_USER_KEY' in os.environ:
-            user_key_opt = { 'default': os.environ.get("WS_USER_KEY") }
+        user_key_opt = { 'default': os.environ.get("WS_USER_KEY") }
     else:
         user_key_opt = { 'required': True }
 

--- a/ws_sbom_generator/sbom_generator.py
+++ b/ws_sbom_generator/sbom_generator.py
@@ -282,8 +282,19 @@ def parse_args():
     real_path = os.path.dirname(os.path.realpath(__file__))
     resource_real_path = os.path.join(real_path, "resources")
     parser = argparse.ArgumentParser(description='Utility to create SBOM from WhiteSource data')
-    parser.add_argument('-u', '--userKey', help="WS User Key", dest='ws_user_key', default=os.environ.get("WS_USER_KEY"), required=True)
-    parser.add_argument('-k', '--token', help="WS Key", dest='ws_token', default=os.environ.get("WS_TOKEN"), required=True)
+    
+    if 'WS_USER_KEY' in os.environ:
+            user_key_opt = { 'default': os.environ.get("WS_USER_KEY") }
+    else:
+        user_key_opt = { 'required': True }
+
+    if 'WS_TOKEN' in os.environ:
+        ws_token_opt = { 'default': os.environ.get("WS_TOKEN") }
+    else:
+        ws_token_opt = { 'required': True }
+    
+    parser.add_argument('-u', '--userKey', help="WS User Key", dest='ws_user_key', **user_key_opt)
+    parser.add_argument('-k', '--token', help="WS Key", dest='ws_token', **ws_token_opt)
     parser.add_argument('-s', '--scope', help="Scope token of SBOM report to generate", dest='scope_token', default=os.environ.get("WS_SCOPE_TOKEN"))
     parser.add_argument('-y', '--tokenType', help="Optional WS Token type to be stated in case WS userKey does not have organization level permissions",
                         dest='ws_token_type',

--- a/ws_sbom_generator/sbom_generator.py
+++ b/ws_sbom_generator/sbom_generator.py
@@ -15,6 +15,7 @@ from spdx.package import Package
 from spdx.relationship import Relationship, RelationshipType
 from spdx.utils import SPDXNone, NoAssert
 from ws_sdk import ws_constants, WS, ws_utilities, ws_errors
+from ws_sdk.ws_constants import ScopeTypes
 
 from ws_sbom_generator._version import __version__, __tool_name__
 
@@ -384,6 +385,10 @@ def main():
         init()
         if args.scope_token:
             scopes = [args.ws_conn.get_scope_by_token(args.scope_token)]
+
+            if scopes[0].get('type') == ScopeTypes.PRODUCT:
+                logger.info(f"Creating SBOM reports on all {scopes[0].get('name')}'s Projects")
+                scopes = args.ws_conn.get_projects(product_token=scopes[0].get('token'))
         else:
             logger.info("Creating SBOM reports on all Organization's Projects")
             scopes = args.ws_conn.get_projects()


### PR DESCRIPTION
In the README.md it states:

```shell
# Run tool as Org Administrator on all projects, default extra args and output in JSON format.
docker run --name ws-sbom-generator \  
  -v /<EXTRA_CONF_DIR>:/opt/ws-sbom-generator/sbom_generator/resources \ 
  -v /<REPORT_OUTPUT_DIR>:/opt/ws-sbom-generator/sbom_generator/output \
  -e WS_USER_KEY=<USER_KEY> \ 
  -e WS_TOKEN=<WS_ORG_TOKEN> \
  -e WS_URL=saas \
  -e WS_REPORT_TYPE=json
  whitesourcetools/ws-sbom-generator
```
can be used to run the tool from a docker container. However when running this, the resulting output is:

```shell
usage: ws_sbom_generator [-h] -u WS_USER_KEY -k WS_TOKEN [-s SCOPE_TOKEN] [-y {product,organization}] [-a WS_URL] [-t {json,tv,rdf,xml,yaml,all}] [-e EXTRA] [-o OUT_DIR]
ws_sbom_generator: error: the following arguments are required: -u/--userKey, -k/--token
```
I tested this outside of the docker environment and it occurs with the normal environment as well.

The reason for this is because with Python's arg parser, the "default" option does not affect the "required" option. Therefore, we have to run a check to determine if it is actually set in the environment variable.

This will fix the issue.